### PR TITLE
Make releases safer, record build information in JARs

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,7 +1,8 @@
 name: Run build on each commit
 on: push
 jobs:
-  gradle:
+  build:
+    name: Gradle build
     runs-on: ubuntu-latest
     steps:
     - name: Checkout project sources
@@ -12,9 +13,11 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         arguments: build --info --stacktrace
-    - name: Upload build reports
+    - name: Upload build artifacts
       if: always()
       uses: actions/upload-artifact@v3
       with:
-        name: build-reports
-        path: build/reports/
+        name: build-artifacts
+        path: |
+          build/libs/
+          build/reports/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -176,6 +176,7 @@ tasks.validatePlugins {
 }
 
 tasks.publishPlugins {
+    dependsOn(tasks.build)
     doFirst {
         val localStatus = checkNotNull(gitStatus) { "Could not query local Git repository" }
         val releaseTag = "v${project.version}"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,16 @@
+import com.github.spotbugs.snom.SpotBugsTask
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.errors.RepositoryNotFoundException
+import org.eclipse.jgit.lib.Constants
+import org.eclipse.jgit.lib.RepositoryBuilder
+import java.net.URI
+
+buildscript {
+    dependencies {
+        classpath("org.eclipse.jgit:org.eclipse.jgit:6.3.0.202209071007-r")
+    }
+}
+
 // --- Gradle infrastructure setup: Gradle distribution to use (run *twice* after modifications) ---
 tasks.wrapper {
     // When changing this version, update `ApplicationPluginFunctionalTest.GRADLE_VERSIONS_SUPPORTED` as well
@@ -22,36 +35,58 @@ version = "2.0.0"
 
 val pluginId = "com.ms.gradle.application"
 val pluginClass = "com.ms.gradle.application.ApplicationPlugin"
-val pluginTitle = "Application plugin for Gradle"
-val pluginDescription = "Allows packaging your Java-based application for distribution, much like " +
+require(pluginId == "${project.group}.${project.name}") { "Inconsistent naming: pluginId" }
+require(pluginClass == "${pluginId}.${project.name.capitalize()}Plugin") { "Inconsistent naming: pluginClass" }
+
+val productVendor = "Morgan Stanley"
+val productTitle = "Application plugin for Gradle"
+val productDescription = "Allows packaging your Java-based applications for distribution, much like " +
         "Gradle's built-in Application plugin does, but in a more standard and more flexible way."
-val pluginUrl = "https://github.com/morganstanley/gradle-plugin-application"
+val productTags = setOf("application", "executable", "jar", "java", "jvm")
+val productUrl = "https://github.com/morganstanley/gradle-plugin-application"
+
+fun <T> queryGit(query: (Git) -> T): T =
+    RepositoryBuilder().setGitDir(file(".git")).setMustExist(true).build().use { query(Git(it)) }
+
+data class GitStatus(val commit: String, val clean: Boolean) {
+    fun asCommit() = if (clean) commit else "${commit}-dirty"
+}
+val gitStatus = try {
+    queryGit { git ->
+        val headOid = checkNotNull(git.repository.resolve(Constants.HEAD)) { "Could not resolve HEAD commit" }
+        val status = git.status().call()!!
+        GitStatus(headOid.name!!, status.isClean)
+    }
+} catch (ex: RepositoryNotFoundException) {
+    null
+}
 
 gradlePlugin {
     plugins.create(project.name) {
         id = pluginId
         implementationClass = pluginClass
-        displayName = pluginTitle
-        description = pluginDescription
+        displayName = productTitle
+        description = productDescription
     }
 }
 
 pluginBundle {
-    website = pluginUrl
-    vcsUrl = pluginUrl
-    pluginTags = mapOf(
-        project.name to setOf("application", "executable", "jar", "java", "jvm"))
+    website = productUrl
+    vcsUrl = productUrl
+    pluginTags = mapOf(project.name to productTags)
 }
 
-tasks.jar {
-    manifest {
-        attributes(
-            "Automatic-Module-Name" to pluginId,
-            "Implementation-Title" to pluginTitle,
-            "Implementation-Version" to project.version,
-            "Implementation-Vendor" to "Morgan Stanley",
-            "Implementation-URL" to pluginUrl)
-    }
+val manifestAttributes by lazy {
+    mapOf(
+        "Automatic-Module-Name" to pluginId,
+        "Implementation-Title" to productTitle,
+        "Implementation-Version" to project.version,
+        "Implementation-Vendor" to productVendor,
+        "Build-Jdk" to System.getProperty("java.version"),
+        "Build-Jdk-Spec" to java.targetCompatibility,
+        "Build-Scm-Commit" to (gitStatus?.asCommit() ?: "unknown"),
+        "Build-Scm-Url" to URI("${productUrl}/tree/").resolve(URI(null, null, "v${project.version}", null)),
+    )
 }
 
 java {
@@ -76,6 +111,10 @@ dependencies {
     testImplementation("commons-io:commons-io:2.11.0")
 }
 
+tasks.withType<Jar> {
+    manifest.attributes(manifestAttributes)
+}
+
 checkstyle {
     toolVersion = "9.3"
     maxErrors = 0
@@ -86,7 +125,7 @@ pmd {
     ruleSets = listOf("category/java/bestpractices.xml")
 }
 
-tasks.withType<com.github.spotbugs.snom.SpotBugsTask> {
+tasks.withType<SpotBugsTask> {
     reports.register("html");
     reports.register("xml");
 }
@@ -95,7 +134,7 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 tasks.test {
-    inputs.dir(projectDir.resolve("test-data"))
+    inputs.dir(file("test-data"))
 
     // Pass the Jacoco Agent JVM argument into the tests so that TestKit can apply it to the JVMs it spawns
     extensions.getByType<JacocoTaskExtension>().let { jacoco ->
@@ -130,8 +169,31 @@ tasks.jacocoTestReport {
     reports.xml.required.set(true)
 }
 
-tasks.withType<ValidatePlugins> {
+tasks.validatePlugins {
     enableStricterValidation.set(true)
     ignoreFailures.set(false)
     failOnWarning.set(true)
+}
+
+tasks.publishPlugins {
+    doFirst {
+        val localStatus = checkNotNull(gitStatus) { "Could not query local Git repository" }
+        val releaseTag = "v${project.version}"
+        val releaseCommit = queryGit { git ->
+            val remoteTags = git.lsRemote().setRemote("${productUrl}.git").setTags(true).callAsMap()
+            val releaseRef = checkNotNull(remoteTags.get("refs/tags/${releaseTag}")) {
+                "Release tag \"${releaseTag}\" does not exist in root repository"
+            }
+            val releaseOid = checkNotNull(releaseRef.run { peeledObjectId ?: objectId }) {
+                "Could not resolve release tag \"${releaseTag}\""
+            }
+            releaseOid.name!!
+        }
+        check(localStatus.commit == releaseCommit) {
+            "Local Git repository must have release tag \"${releaseTag}\" checked out for publication"
+        }
+        check(localStatus.clean) {
+            "Local Git repository must be in a clean state for publication"
+        }
+    }
 }


### PR DESCRIPTION
- [Ensure reproducible releases, record build information in JAR manifests](https://github.com/morganstanley/gradle-plugin-application/commit/4534614066563f07dc5bbb075c4c7a3a7e3d9670)
- [Require a full successful build before releasing](https://github.com/morganstanley/gradle-plugin-application/commit/b8889cecb57bfdff4d3bee699500bf792836b209)
- [Upload JARs built by the `build` GitHub Action](https://github.com/morganstanley/gradle-plugin-application/commit/0e9150795761ed14908564b8f4ca6a20804783fa)