### PR TITLE
Test using multiple Java versions, add external Javadoc links

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -7,6 +7,14 @@ jobs:
     steps:
     - name: Checkout project sources
       uses: actions/checkout@v3
+    - name: Setup Java toolchains
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'zulu'
+        java-version: |
+          8
+          11
+          17
     - name: Validate Gradle wrapper
       uses: gradle/wrapper-validation-action@v1
     - name: Run Gradle build

--- a/src/main/java/com/ms/gradle/application/ApplicationJar.java
+++ b/src/main/java/com/ms/gradle/application/ApplicationJar.java
@@ -295,9 +295,12 @@ public abstract class ApplicationJar extends Jar implements ApplicationSpec {
         manifest.getAttributes().clear();
     }
 
-    // Only overridden here to make the `@TaskAction` method visible to tests
+    /**
+     * Executes this task.
+     */
     @Override
     protected void copy() {
+        // Only overridden here to make the `@TaskAction` method visible to tests
         super.copy();
     }
 

--- a/src/test/java/com/ms/gradle/application/ApplicationPluginTest.java
+++ b/src/test/java/com/ms/gradle/application/ApplicationPluginTest.java
@@ -68,7 +68,7 @@ class ApplicationPluginTest {
     @Nonnull
     private final Project project;
 
-    public ApplicationPluginTest() {
+    ApplicationPluginTest() {
         project = ProjectBuilder.builder().withName(TEST_NAME).build();
         project.getPluginManager().apply(PLUGIN_ID);
     }

--- a/src/test/java/com/ms/gradle/application/UtilsTest.java
+++ b/src/test/java/com/ms/gradle/application/UtilsTest.java
@@ -82,8 +82,8 @@ class UtilsTest {
         Assertions.assertThat(Utils.capitalize("3.14")).isEqualTo("3.14");
         Assertions.assertThat(Utils.capitalize("-3.14")).isEqualTo("-3.14");
 
-        Assertions.assertThat(Utils.capitalize("árvíztűrő")).isEqualTo("Árvíztűrő");
-        Assertions.assertThat(Utils.capitalize("Árvíztűrő")).isEqualTo("Árvíztűrő");
+        Assertions.assertThat(Utils.capitalize("árvízTűrő")).isEqualTo("ÁrvízTűrő");
+        Assertions.assertThat(Utils.capitalize("ÁrvízTűrő")).isEqualTo("ÁrvízTűrő");
         Assertions.assertThat(Utils.capitalize("tükörFúróGép")).isEqualTo("TükörFúróGép");
         Assertions.assertThat(Utils.capitalize("TükörFúróGép")).isEqualTo("TükörFúróGép");
         Assertions.assertThat(Utils.capitalize("őrTűz")).isEqualTo("ŐrTűz");


### PR DESCRIPTION
- Run our Gradle build using Java 17
- Use Java 11 toolkit for most tasks (e.g. `JavaCompile` and `Javadoc`)
- Add external Javadoc links
- Test using Java 8, 11 and 17
  - Functional tests limited to compatible Gradle versions
  - Restructured functional tests to execute all test cases for the same Gradle version in a batch, allowing better reuse of the TestKit JVM / Gradle daemon
- Use meaningful Jacoco session IDs (even in functional tests)
- Enable Jacoco test coverage verification (100%)