### PR TITLE
Use latest Java toolchain and simplify Javadoc generation now that the `javadoc` tool can properly link to older docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The plugin adds an extension named `applications` to the project, which is a con
 // build.gradle
 
 plugins {
-    id "com.ms.gradle.application" version "2.0.2"
+    id "com.ms.gradle.application" version "2.0.3"
 }
 
 applications.main {
@@ -64,7 +64,7 @@ For more complex examples, see the [build file of the plugin's functional test](
 // build.gradle.kts
 
 plugins {
-    id("com.ms.gradle.application").version("2.0.2")
+    id("com.ms.gradle.application").version("2.0.3")
 }
 
 applications.main {


### PR DESCRIPTION
Use latest Java toolchain and simplify Javadoc generation now that the `javadoc` tool can properly link to older docs with the following tickets fully complete:
* [JDK-8216497 – javadoc should auto-link to platform classes](https://bugs.openjdk.org/browse/JDK-8216497)
* [JDK-8297437 – javadoc cannot link to old docs (with old style anchors)](https://bugs.openjdk.org/browse/JDK-8297437)

----

The only remaining issue is Gradle's own Javadocs, in that
* it would currently require HTML4 format fragments at the end of the links (e.g. [`Project.html#getName--`](https://docs.gradle.org/8.4/javadoc/org/gradle/api/Project.html#getName--)),
* but it tricks the new, smart `javadoc` implementation into generating them in HTML5 format (e.g. [`Project.html#getName()`](https://docs.gradle.org/8.4/javadoc/org/gradle/api/Project.html#getName())),
* so the deep links don't work properly.

I will try to ask the Gradle maintainers to fix this before I merge this PR. The possible solutions:
* They could also start using Java 17+'s `javadoc` and generate modern HTML5, which would also fix their links to JDK classes
  * https://github.com/gradle/gradle/blob/v8.4.0/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleJavadocsPlugin.java#L106-L109
* They could remove the `element-list` and only keep `package-list` if the docs have to be in HTML4 format
  * [This `element-list` file being there is what misleads the new, smart `javadoc` implementation](https://github.com/openjdk/jdk17u-dev/blob/jdk-17.0.7+7/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/Extern.java#L435-L471) – if there is an `element-list`, then it calls `readElementList(in, urlpath, false, 0, false)`, otherwise it does the same with a `true` as the last parameter (`isOldFormDoc`)
  *  https://github.com/gradle/gradle/blob/v8.4.0/build-logic/documentation/src/main/groovy/gradlebuild/docs/GradleJavadocsPlugin.java#L113-L126